### PR TITLE
Add lexer, parser, and main program for workflow DSL with sample input and build setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+CC = gcc
+
+all: compiler
+
+compiler: lexer.o parser.o main.o
+	$(CC) -o compiler lexer.o parser.o main.o
+
+# Bison generates both files
+parser.tab.h parser.c: parser.y
+	bison -d -o parser.c parser.y
+
+# Compile parser.c (after parser.c exists)
+parser.o: parser.c
+	$(CC) -c parser.c
+
+# Flex should only run AFTER parser.tab.h exists
+lexer.c: lexer.l parser.tab.h
+	flex -o lexer.c lexer.l
+
+# Compile lexer.c (after lexer.c exists)
+lexer.o: lexer.c
+	$(CC) -c lexer.c
+
+main.o: main.c
+	$(CC) -c main.c
+
+clean:
+	rm -f *.o *.c *.h compiler

--- a/input.yaml
+++ b/input.yaml
@@ -1,0 +1,12 @@
+workflow: "deploy_app"
+tasks: [
+  {
+    name: "build",
+    command: "make build"
+  },
+  {
+    name: "test",
+    command: "make test",
+    depends_on: ["build"]
+  }
+]

--- a/lexer.l
+++ b/lexer.l
@@ -1,0 +1,65 @@
+%{
+    #include "parser.h"
+    #include <stdlib.h>
+    #include <string.h>
+
+    char *copy_string(const char *text);
+%}
+
+%%
+
+"workflow" {
+    return WORKFLOW;
+}
+"name" {
+    return NAME;
+}
+"tasks" {
+    return TASKS;
+}
+"command" {
+    return COMMAND;
+}
+"depends_on" {
+    return DEPENDS_ON;
+}
+\"[^\"]+\" {
+    char *raw = yytext;
+    size_t len = strlen(raw);
+    char *unquoted = (char *)malloc(len - 1);  // len - 2 for quotes + 1 for \0
+    strncpy(unquoted, raw + 1, len - 2);
+    unquoted[len - 2] = '\0';
+    yylval.str = unquoted;
+    return STRING;
+}
+[a-zA-Z_][a-zA-Z0-9_-]* {
+    yylval.str = copy_string(yytext);
+    return ID;
+}
+[0-9]+ {
+    yylval.num = atoi(yytext);
+    return NUMBER;
+}
+[\[\]{},:] {
+    return yytext[0];
+}
+[ \t\r\n]+ {
+    // skip whitespace
+}
+. {
+    return yytext[0];
+}
+
+%%
+
+char* copy_string(const char* text) {
+    size_t len = strlen(text);
+    char* result = (char*)malloc(len + 1);
+    strncpy(result, text, len);
+    result[len] = '\0';
+    return result;
+}
+
+int yywrap() {
+    return 1;
+}

--- a/main.c
+++ b/main.c
@@ -1,0 +1,23 @@
+#include <stdio.h>
+extern int yyparse();
+extern FILE *yyin;
+
+int yydebug = 1;  // Enable parser debug output
+
+int main(int argc, char *argv[]) {
+    if (argc != 2) {
+        printf("Usage: %s <input.yaml>\n", argv[0]);
+        return 1;
+    }
+
+    FILE *file = fopen(argv[1], "r");
+    if (!file) {
+        perror("File opening failed");
+        return 1;
+    }
+
+    yyin = file;
+    yyparse();
+    fclose(file);
+    return 0;
+}

--- a/parser.y
+++ b/parser.y
@@ -1,0 +1,81 @@
+%{
+    #include <stdio.h>
+    #include <stdlib.h>
+    #include <string.h>
+    
+    void yyerror(const char *s);
+    int yylex(void);
+    %}
+    
+    %union {
+        int num;
+        char* str;
+    }
+    
+    %token <str> STRING ID
+    %token <num> NUMBER
+    
+    %token WORKFLOW NAME TASKS COMMAND DEPENDS_ON
+    
+    %type <str> name_field command_field depends_on_field
+    
+    %%
+    
+    program:
+        workflow_block
+        ;
+    
+    workflow_block:
+        WORKFLOW ':' STRING task_section
+        {
+            printf("Parsed workflow: %s\n", $3);
+        }
+        ;
+    
+    task_section:
+        TASKS ':' '[' task_list ']'
+        ;
+    
+    task_list:
+        task_item
+        | task_list ',' task_item
+        ;
+    
+    task_item:
+        '{' task_body '}'
+        ;
+    
+    task_body:
+        name_field ',' command_field
+        {
+            printf("  Task: %s\n", $1);
+            printf("  Command: %s\n", $3);
+        }
+        |
+        name_field ',' command_field ',' depends_on_field
+        {
+            printf("  Task: %s\n", $1);
+            printf("  Command: %s\n", $3);
+            printf("  Depends On: %s\n", $5);
+        }
+        ;
+    
+    name_field:
+        NAME ':' STRING { $$ = $3; }
+        ;
+    
+    command_field:
+        COMMAND ':' STRING { $$ = $3; }
+        ;
+    
+    depends_on_field:
+        DEPENDS_ON ':' '[' STRING ']' { $$ = $4; }
+        ;
+    
+    %%
+    
+    void yyerror(const char *s) {
+        extern int yylineno;
+        fprintf(stderr, "Error at line %d: %s\n", yylineno, s);
+    }
+    


### PR DESCRIPTION
This pull request introduces a complete lexer and parser implementation for a custom workflow DSL, including:

- Lexer (lexer.l): Tokenizes the DSL keywords, strings, identifiers, numbers, and symbols without debug output.

- Parser (parser.y): Defines grammar rules to parse workflow definitions, tasks, commands, and dependencies; outputs a clean summary of the parsed workflow.

- Main program (main.c): Drives the lexer and parser with file input handling and error reporting.

- Makefile: Automates the build process using Flex and Bison, compiling all components into a compiler executable.

- Sample input (input.yaml): Provides a test workflow YAML illustrating tasks with dependencies for validation.

This setup allows parsing structured workflow descriptions, printing a user-friendly summary, and lays the groundwork for further extensions or integration.