### PR TITLE
 Introduce Intermediate Representation (IR) layer and integrate into build and main workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ CFLAGS = -Wall -g -Iinclude
 
 all: compiler
 
-compiler: lexer.o parser.o main.o ast.o
-	$(CC) $(CFLAGS) -o compiler lexer.o parser.o main.o ast.o
+compiler: lexer.o parser.o main.o ast.o ir.o
+	$(CC) $(CFLAGS) -o compiler lexer.o parser.o main.o ast.o ir.o
 
 # Bison generates both files
 parser.tab.h parser.c: parser.y
@@ -27,6 +27,9 @@ main.o: main.c
 
 ast.o: src/ast.c
 	$(CC) $(CFLAGS) -c src/ast.c -o ast.o
+
+ir.o: src/ir.c include/ir.h include/ast.h
+	$(CC) $(CFLAGS) -c src/ir.c -o ir.o
 
 clean:
 	rm -f *.o parser.c parser.h lexer.c compiler

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 CC = gcc
+CFLAGS = -Wall -g -Iinclude
 
 all: compiler
 
-compiler: lexer.o parser.o main.o
-	$(CC) -o compiler lexer.o parser.o main.o
+compiler: lexer.o parser.o main.o ast.o
+	$(CC) $(CFLAGS) -o compiler lexer.o parser.o main.o ast.o
 
 # Bison generates both files
 parser.tab.h parser.c: parser.y
@@ -11,7 +12,7 @@ parser.tab.h parser.c: parser.y
 
 # Compile parser.c (after parser.c exists)
 parser.o: parser.c
-	$(CC) -c parser.c
+	$(CC) $(CFLAGS) -c parser.c
 
 # Flex should only run AFTER parser.tab.h exists
 lexer.c: lexer.l parser.tab.h
@@ -19,10 +20,13 @@ lexer.c: lexer.l parser.tab.h
 
 # Compile lexer.c (after lexer.c exists)
 lexer.o: lexer.c
-	$(CC) -c lexer.c
+	$(CC) $(CFLAGS) -c lexer.c
 
 main.o: main.c
-	$(CC) -c main.c
+	$(CC) $(CFLAGS) -c main.c
+
+ast.o: src/ast.c
+	$(CC) $(CFLAGS) -c src/ast.c -o ast.o
 
 clean:
-	rm -f *.o *.c *.h compiler
+	rm -f *.o parser.c parser.h lexer.c compiler

--- a/include/ast.h
+++ b/include/ast.h
@@ -1,0 +1,23 @@
+#ifndef AST_H
+#define AST_H
+
+typedef struct Task {
+    char *name;
+    char *command;
+    char **depends_on;  // array of strings (task names)
+    int depends_count;
+    struct Task *next;
+} Task;
+
+typedef struct Workflow {
+    char *name;
+    Task *tasks;
+} Workflow;
+
+Workflow* create_workflow(const char *name);
+Task* create_task(const char *name, const char *command);
+void add_task(Workflow *wf, Task *task);
+void free_workflow(Workflow *wf);
+void print_workflow(const Workflow *wf);
+
+#endif // AST_H

--- a/include/ir.h
+++ b/include/ir.h
@@ -1,0 +1,23 @@
+#ifndef IR_H
+#define IR_H
+
+typedef struct IRTask {
+    char *name;
+    char *command;
+    char **depends_on;
+    int depends_count;
+    struct IRTask *next;
+} IRTask;
+
+typedef struct IRWorkflow {
+    char *name;
+    IRTask *tasks;
+} IRWorkflow;
+
+#include "ast.h"
+
+IRWorkflow* generate_ir(Workflow *wf);
+void print_ir(IRWorkflow *ir);
+void free_ir(IRWorkflow *ir);
+
+#endif

--- a/main.c
+++ b/main.c
@@ -2,6 +2,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include "include/ast.h"
+#include "ir.h"
+
 
 extern int yyparse();
 extern FILE *yyin;
@@ -60,6 +62,18 @@ int main(int argc, char *argv[]) {
         }
 
         print_workflow(workflow);
+        IRWorkflow *ir = generate_ir(workflow);
+        if (!ir) {
+            fprintf(stderr, "IR generation failed.\n");
+            fclose(file);
+            free_workflow(workflow);
+            return 1;
+        }
+
+        printf("\n--- IR ---\n");
+        print_ir(ir);
+        free_ir(ir);
+        
         free_workflow(workflow);
     } else {
         fprintf(stderr, "Parsing failed.\n");

--- a/main.c
+++ b/main.c
@@ -1,12 +1,40 @@
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "include/ast.h"
+
 extern int yyparse();
 extern FILE *yyin;
+extern Workflow *workflow;
 
-int yydebug = 1;  // Enable parser debug output
+int yydebug = 1;
+
+int check_dependencies(Workflow *wf) {
+    Task *t = wf->tasks;
+    while (t) {
+        for (int i = 0; i < t->depends_count; i++) {
+            int found = 0;
+            Task *search = wf->tasks;
+            while (search) {
+                if (strcmp(search->name, t->depends_on[i]) == 0) {
+                    found = 1;
+                    break;
+                }
+                search = search->next;
+            }
+            if (!found) {
+                fprintf(stderr, "Semantic error: Task '%s' depends on undefined task '%s'\n", t->name, t->depends_on[i]);
+                return 0;
+            }
+        }
+        t = t->next;
+    }
+    return 1;
+}
 
 int main(int argc, char *argv[]) {
     if (argc != 2) {
-        printf("Usage: %s <input.yaml>\n", argv[0]);
+        fprintf(stderr, "Usage: %s <input.yaml>\n", argv[0]);
         return 1;
     }
 
@@ -17,7 +45,26 @@ int main(int argc, char *argv[]) {
     }
 
     yyin = file;
-    yyparse();
+
+    if (yyparse() == 0) {
+        if (!workflow) {
+            fprintf(stderr, "No workflow parsed.\n");
+            fclose(file);
+            return 1;
+        }
+
+        if (!check_dependencies(workflow)) {
+            fclose(file);
+            free_workflow(workflow);
+            return 1;
+        }
+
+        print_workflow(workflow);
+        free_workflow(workflow);
+    } else {
+        fprintf(stderr, "Parsing failed.\n");
+    }
+    
     fclose(file);
     return 0;
 }

--- a/src/ast.c
+++ b/src/ast.c
@@ -1,0 +1,65 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "ast.h"
+
+Workflow* create_workflow(const char *name) {
+    Workflow *wf = malloc(sizeof(Workflow));
+    wf->name = strdup(name);
+    wf->tasks = NULL;
+    return wf;
+}
+
+Task* create_task(const char *name, const char *command) {
+    Task *t = malloc(sizeof(Task));
+    t->name = strdup(name);
+    t->command = strdup(command);
+    t->depends_on = NULL;
+    t->depends_count = 0;
+    t->next = NULL;
+    return t;
+}
+
+void add_task(Workflow *wf, Task *task) {
+    if (!wf->tasks) {
+        wf->tasks = task;
+    } else {
+        Task *curr = wf->tasks;
+        while (curr->next) curr = curr->next;
+        curr->next = task;
+    }
+}
+
+void free_workflow(Workflow *wf) {
+    if (!wf) return;
+    free(wf->name);
+    Task *t = wf->tasks;
+    while (t) {
+        Task *next = t->next;
+        free(t->name);
+        free(t->command);
+        for (int i = 0; i < t->depends_count; i++) {
+            free(t->depends_on[i]);
+        }
+        free(t->depends_on);
+        free(t);
+        t = next;
+    }
+    free(wf);
+}
+
+void print_workflow(const Workflow *wf) {
+    printf("Workflow: %s\n", wf->name);
+    Task *t = wf->tasks;
+    while (t) {
+        printf(" Task: %s\n", t->name);
+        printf("  Command: %s\n", t->command);
+        if (t->depends_count > 0) {
+            printf("  Depends on: ");
+            for (int i = 0; i < t->depends_count; i++) {
+                printf("%s%s", t->depends_on[i], (i == t->depends_count - 1) ? "\n" : ", ");
+            }
+        }
+        t = t->next;
+    }
+}

--- a/src/ir.c
+++ b/src/ir.c
@@ -1,0 +1,75 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "ir.h"
+
+IRTask* create_ir_task(Task *t) {
+    IRTask *ir = malloc(sizeof(IRTask));
+    ir->name = strdup(t->name);
+    ir->command = strdup(t->command);
+    ir->depends_count = t->depends_count;
+
+    if (t->depends_count > 0) {
+        ir->depends_on = malloc(sizeof(char *) * t->depends_count);
+        for (int i = 0; i < t->depends_count; ++i) {
+            ir->depends_on[i] = strdup(t->depends_on[i]);
+        }
+    } else {
+        ir->depends_on = NULL;
+    }
+
+    ir->next = NULL;
+    return ir;
+}
+
+IRWorkflow* generate_ir(Workflow *wf) {
+    IRWorkflow *ir = malloc(sizeof(IRWorkflow));
+    ir->name = strdup(wf->name);
+    ir->tasks = NULL;
+
+    IRTask *tail = NULL;
+    for (Task *t = wf->tasks; t != NULL; t = t->next) {
+        IRTask *ir_task = create_ir_task(t);
+        if (!ir->tasks) {
+            ir->tasks = ir_task;
+            tail = ir_task;
+        } else {
+            tail->next = ir_task;
+            tail = ir_task;
+        }
+    }
+
+    return ir;
+}
+
+void print_ir(IRWorkflow *ir) {
+    printf("IR Workflow: %s\n", ir->name);
+    for (IRTask *t = ir->tasks; t; t = t->next) {
+        printf("  Task: %s\n", t->name);
+        printf("    Command: %s\n", t->command);
+        if (t->depends_count > 0) {
+            printf("    Depends On: ");
+            for (int i = 0; i < t->depends_count; ++i) {
+                printf("%s ", t->depends_on[i]);
+            }
+            printf("\n");
+        }
+    }
+}
+
+void free_ir(IRWorkflow *ir) {
+    IRTask *t = ir->tasks;
+    while (t) {
+        IRTask *next = t->next;
+        free(t->name);
+        free(t->command);
+        for (int i = 0; i < t->depends_count; ++i) {
+            free(t->depends_on[i]);
+        }
+        free(t->depends_on);
+        free(t);
+        t = next;
+    }
+    free(ir->name);
+    free(ir);
+}


### PR DESCRIPTION
This PR adds an Intermediate Representation (IR) layer for workflow tasks, enabling a cleaner separation between parsing (AST) and subsequent processing stages. It includes:
- Added `ir.h` and `ir.c` implementing IRTask and IRWorkflow structures and related functions:

- `generate_ir` converts the AST Workflow into IRWorkflow

- `print_ir` prints the IR structure

- `free_ir` properly frees IR resources

- Updated `main.c` to generate IR after parsing and semantic checks, print the IR, and clean up IR memory

- Modified the `Makefile` to compile and link ir.o and properly include IR headers in dependencies

These changes prepare the codebase for future phases such as IR optimization or code generation by introducing a dedicated IR abstraction.